### PR TITLE
add route to grab all of a user's habits

### DIFF
--- a/routes/api/habits.js
+++ b/routes/api/habits.js
@@ -14,6 +14,18 @@ router.get('/', (req, res) => {
         .catch(err => res.status(404).json({ nohabitsfound: 'No habits found' }));
 });
 
+router.get(
+  "/currentUser",
+  passport.authenticate('jwt', {session: false }),
+  (req, res) => {
+    Habit.find( { user: req.user.id })
+      .then(  habits => res.json(habits))
+      .catch( err    => res.status(402)
+                           .json({ nocurrentuser: "no current user" })
+            )
+  }
+);
+
 router.get('/:id', (req, res) => {
     Habit.findById(req.params.id)
         .then(habit => res.json(habit))


### PR DESCRIPTION
the current user needs to access their own habits so that we can render a proper profile page

tested via axios in the browser

I'm open to feedback about the choice of url (currently `/api/habits/currentuser`)