### PR TITLE
fixing navbar animations for firefox

### DIFF
--- a/frontend/src/components/nav/navbar.css
+++ b/frontend/src/components/nav/navbar.css
@@ -23,6 +23,7 @@
     flex-direction: inherit;
     height: 0;
     max-height: 0;
+    bottom: 12px;
     justify-content: space-between;
     z-index: -100;
     transition: .5s ease-in-out;


### PR DESCRIPTION
firefox doesn't know that you need stuff anchored to the bottom unless you tell it directly.