### PR TITLE
fix receiving single habits by only using a single reducer/action set of instructions for the task

### DIFF
--- a/frontend/src/actions/habit_actions.js
+++ b/frontend/src/actions/habit_actions.js
@@ -1,6 +1,6 @@
 import {
   getHabits,
-  getHabitId,
+  getHabit,
   writeHabit,
   patchHabit,
   getCurrentUserHabits,
@@ -22,11 +22,6 @@ export const receiveHabit = habit => ({
     habit
   });
 
-export const receiveHabitId = habit => ({
-    type: RECEIVE_HABIT_ID,
-    habit
-});
-
 export const receiveNewHabit = habit => ({
     type: RECEIVE_NEW_HABIT,
     habit
@@ -43,9 +38,9 @@ export const fetchHabits = () => dispatch => (
       .catch(err => console.log(err))
   );
 
-export const fetchHabitId = id => dispatch => (
-    getHabitId(id)
-      .then(habits => dispatch(receiveHabitId(habits)))
+export const fetchHabit = id => dispatch => (
+    getHabit(id)
+      .then(habits => dispatch(receiveHabit(habits)))
       .catch(err => console.log(err))
 );
 

--- a/frontend/src/components/habits/habit_show.jsx
+++ b/frontend/src/components/habits/habit_show.jsx
@@ -8,11 +8,11 @@ import './habit_show.css';
 class HabitShow extends React.Component {
   componentDidMount() {
     const {
-      fetchHabitId,
+      fetchHabit,
       fetchHabitResources,
       match: { params: { habitId }},
     } = this.props;
-    fetchHabitId(habitId);
+    fetchHabit(habitId);
     fetchHabitResources(habitId);
   }
 

--- a/frontend/src/components/habits/habit_show_container.jsx
+++ b/frontend/src/components/habits/habit_show_container.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import HabitShow from './habit_show';
 import { fetchHabitResources } from '../../actions/resource_actions';
-import { fetchHabitId } from '../../actions/habit_actions';
+import { fetchHabit } from '../../actions/habit_actions';
 import { openNewResourceModal }
   from '../../actions/modal/resource_modal_actions.js'
 
@@ -33,7 +33,7 @@ const mapStateToProps = (
 
 const mapDispatchToProps = {
   fetchHabitResources,
-  fetchHabitId,
+  fetchHabit,
   openNewResourceModal,
 };
 

--- a/frontend/src/util/habit_api_util.js
+++ b/frontend/src/util/habit_api_util.js
@@ -7,7 +7,7 @@ export const getHabits = () => {
 export const getCurrentUserHabits = () =>
   axios.get('/api/habits/currentUser');
 
-export const getHabitId = id => {
+export const getHabit = id => {
   return axios.get(`/api/habits/${id}`)
 };
 


### PR DESCRIPTION
removes misleading habitId actions