### PR TITLE
fix modal fading on successful form submission

### DIFF
--- a/frontend/src/actions/habit_actions.js
+++ b/frontend/src/actions/habit_actions.js
@@ -46,14 +46,19 @@ export const removeHabit = habitId => ({
     habitId,
 });
 
+const _handleHabitErrors = err => dispatch => {
+  dispatch(receiveHabitErrors(err.response.data));
+  return "fail";
+}
+
 export const fetchHabits = () => dispatch => (
     getHabits()
       .then(
         habits => dispatch(receiveHabits(habits))
       )
-      .catch(err => {
-        dispatch(receiveHabitErrors(err.response.data));
-      })
+      .catch(err =>
+        dispatch(_handleHabitErrors(err))
+      )
   );
 
 export const fetchHabit = id => dispatch => (
@@ -61,9 +66,9 @@ export const fetchHabit = id => dispatch => (
       .then(
         habits => dispatch(receiveHabit(habits))
       )
-      .catch(err => {
-        dispatch(receiveHabitErrors(err.response.data));
-      })
+      .catch(err =>
+        dispatch(_handleHabitErrors(err))
+      )
 );
 
 export const composeHabit = data => dispatch => (
@@ -71,9 +76,9 @@ export const composeHabit = data => dispatch => (
       .then(
         habit => dispatch(receiveHabit(habit))
       )
-      .catch(err => {
-        dispatch(receiveHabitErrors(err.response.data));
-      })
+      .catch(err =>
+        dispatch(_handleHabitErrors(err))
+      )
   );
 
 export const updateHabit = (habitId, data) => dispatch => (
@@ -81,9 +86,9 @@ export const updateHabit = (habitId, data) => dispatch => (
       .then(
         habit => dispatch(receiveHabit(habit))
       )
-      .catch(err => {
-        dispatch(receiveHabitErrors(err.response.data));
-      })
+      .catch(err =>
+        dispatch(_handleHabitErrors(err))
+      )
 )
 
 export const fetchCurrentUserHabits = () => dispatch =>
@@ -91,15 +96,15 @@ export const fetchCurrentUserHabits = () => dispatch =>
       .then( 
         habits => dispatch(receiveCurrentUserHabits(habits))
       )
-      .catch(err => {
-        dispatch(receiveHabitErrors(err.response.data));
-      })
+      .catch(err =>
+        dispatch(_handleHabitErrors(err))
+      )
 
 export const destroyHabit = habitId => dispatch =>
     deleteHabit(habitId)
       .then( 
         () => dispatch(removeHabit(habitId))
       )
-      .catch(err => {
-        dispatch(receiveHabitErrors(err.response.data));
-      })
+      .catch(err =>
+        dispatch(_handleHabitErrors(err))
+      )

--- a/frontend/src/actions/resource_actions.js
+++ b/frontend/src/actions/resource_actions.js
@@ -50,14 +50,19 @@ export const removeResource = resourceId => ({
   resourceId
 })
 
+const _handleResourceErrors = err => dispatch => {
+  dispatch(receiveResourceErrors(err.response.data));
+  return "fail";
+}
+
 export const fetchResources = () => dispatch => {
   return resources_util.fetchResources()
       .then( 
         ({data: resources}) => dispatch(receiveAllResources(resources))
       )
-      .catch(err => {
-        dispatch(receiveResourceErrors(err.response.data));
-      })
+      .catch(err =>
+        dispatch(_handleResourceErrors(err))
+      )
 }
 
 export const fetchHabitResources = habitId => dispatch =>
@@ -68,18 +73,18 @@ export const fetchHabitResources = habitId => dispatch =>
     })
     .then( resources =>
       dispatch(receiveAllResources(resources)))
-    .catch(err => {
-      dispatch(receiveResourceErrors(err.response.data));
-    })
+    .catch(err =>
+      dispatch(_handleResourceErrors(err))
+    )
 
 export const fetchResource = ResourceId => dispatch => (
   resources_util.fetchResource(ResourceId)
     .then( 
       ({data: resource}) => dispatch(receiveResource(resource))
     )
-    .catch(err => {
-      dispatch(receiveResourceErrors(err.response.data));
-    })
+    .catch(err =>
+      dispatch(_handleResourceErrors(err))
+    )
 )
 
 export const createResource = resource => dispatch => (
@@ -93,18 +98,18 @@ export const createResource = resource => dispatch => (
                                     Object.keys(resourceObj)[0]));
     })
     .then( () => dispatch(clearNewResource()) )
-    .catch(err => {
-      dispatch(receiveResourceErrors(err.response.data));
-    })
+    .catch(err =>
+      dispatch(_handleResourceErrors(err))
+    )
 )
 
 export const updateResource= resource => dispatch => (
   resources_util.updateResource(resource)
     .then( ({data: resource}) => dispatch(receiveResource(resource)))
     .then( () => dispatch(clearNewResource()) )
-    .catch(err => {
-      dispatch(receiveResourceErrors(err.response.data));
-    })
+    .catch(err =>
+      dispatch(_handleResourceErrors(err))
+    )
 )
 
 export const deleteResource = resourceId => dispatch => (
@@ -112,7 +117,7 @@ export const deleteResource = resourceId => dispatch => (
     .then(
       () => dispatch(removeResource(resourceId))
     )
-    .catch(err => {
-      dispatch(receiveResourceErrors(err.response.data));
-    })
+    .catch(err =>
+      dispatch(_handleResourceErrors(err))
+    )
 )

--- a/frontend/src/components/habits/habit_compose.js
+++ b/frontend/src/components/habits/habit_compose.js
@@ -31,14 +31,15 @@ class HabitCompose extends React.Component {
       title,
       description,
     };
-
     e.preventDefault();
-    if(habit) {
-      updateHabit(habit._id, newHabit);
-    } else {
-      composeHabit(newHabit);
-    }
-    closeModal();
+    const promiseAction = habit ? () => updateHabit(habit._id, newHabit)
+                                : () => composeHabit(newHabit);
+    promiseAction()
+      .then(res => {
+        console.log(res);
+        if(res !== "fail")
+          closeModal();
+      });
   }
 
   update(key) {

--- a/frontend/src/components/habits/habit_compose.js
+++ b/frontend/src/components/habits/habit_compose.js
@@ -25,6 +25,7 @@ class HabitCompose extends React.Component {
       updateHabit,
       closeModal,
       habit,
+      receiveNewHabit,
     } = this.props;
 
     const newHabit = {
@@ -36,9 +37,10 @@ class HabitCompose extends React.Component {
                                 : () => composeHabit(newHabit);
     promiseAction()
       .then(res => {
-        console.log(res);
-        if(res !== "fail")
+        if(res !== "fail") {
+          receiveNewHabit({title: "", description: ""});
           closeModal();
+        }
       });
   }
 

--- a/frontend/src/components/habits/habit_delete_confirmation.jsx
+++ b/frontend/src/components/habits/habit_delete_confirmation.jsx
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import { closeModal } from '../../actions/modal/modal_common_actions';
 import { destroyHabit } from "../../actions/habit_actions";
 
 import entityDeleteConfirmPrompt from '../modal/confirm_delete';
@@ -29,6 +30,7 @@ const mSTP = ({
 
 const mDTP = {
   deleteEntityCallback: destroyHabit,
+  closeModal,
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({

--- a/frontend/src/components/modal/confirm_delete.jsx
+++ b/frontend/src/components/modal/confirm_delete.jsx
@@ -8,6 +8,7 @@ import './confirm_delete.css';
 const entityDeleteConfirmPrompt = ({
   type,
   title,
+  closeModal,
   deleteEntityCallback,
 }) => {
   const [ titleInput, setTitleInput ] = useState('');
@@ -21,8 +22,13 @@ const entityDeleteConfirmPrompt = ({
   const handleSubmit = event => {
     event.preventDefault();
     if(!disabled) {
-      deleteEntityCallback();
-      history.goBack();
+      deleteEntityCallback()
+        .then(res => {
+          if(res !== "fail") {
+            history.goBack();
+            closeModal();
+          }
+        })
     }
   }
 

--- a/frontend/src/components/resources/resource_delete_confirmation.jsx
+++ b/frontend/src/components/resources/resource_delete_confirmation.jsx
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 
 import { deleteResource } from '../../actions/resource_actions';
 import entityDeleteConfirmPrompt from '../modal/confirm_delete';
+import { closeModal } from '../../actions/modal/modal_common_actions';
 
 const mSTP = ({
   entities: {
@@ -28,6 +29,7 @@ const mSTP = ({
 
 const mDTP = {
   deleteEntityCallback: deleteResource,
+  closeModal,
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {

--- a/frontend/src/components/resources/resource_form.jsx
+++ b/frontend/src/components/resources/resource_form.jsx
@@ -22,16 +22,21 @@ class ResourceForm extends React.Component {
           updateResource,
           newResource,
           editResource,
+          closeModal,
         } = this.props;
         e.preventDefault();
-        if(editResource) {
-          updateResource({
-            ...newResource,
-            _id: editResource._id,
-          });
-        } else {
-          createResource(newResource);
-        }
+      const promiseAction =
+        editResource ? () => updateResource(
+                               {...newResource, _id: editResource.id } 
+                             )
+                     : () => createResource(newResource);
+
+      promiseAction()
+        .then( res => {
+          if(res !== "fail") {
+            closeModal();
+          }
+        });
     }
 
     update(field) {

--- a/frontend/src/components/resources/resource_form_container.js
+++ b/frontend/src/components/resources/resource_form_container.js
@@ -5,6 +5,8 @@ import {
   receiveNewResource,
   updateResource,
 } from '../../actions/resource_actions';
+import { closeModal }
+  from '../../actions/modal/modal_common_actions';
 
 const mSTP = (state) => {
   const newResource = state.entities.resources.new;
@@ -22,6 +24,7 @@ const mDTP = ({
   createResource,
   receiveNewResource,
   updateResource,
+  closeModal,
 });
 
 export default connect(mSTP, mDTP)(ResourceForm);


### PR DESCRIPTION
If I were to redo this, I realized I could do something way simpler by using the state sub-reducer in the modal's slice of state instead of having to add any promise chaining or anything, but hey, this works