### PR TITLE
Revert "Itai's Redux Logger as dev-dependency changes"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,13 +18,13 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
         "redux": "^4.0.5",
+        "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
         "web-vitals": "^1.0.1"
       },
       "devDependencies": {
         "eslint": "^7.23.0",
-        "eslint-plugin-react": "^7.23.1",
-        "redux-logger": "^3.0.6"
+        "eslint-plugin-react": "^7.23.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "redux": "^4.0.5",
+    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "web-vitals": "^1.0.1"
   },
@@ -45,7 +46,6 @@
   },
   "devDependencies": {
     "eslint": "^7.23.0",
-    "eslint-plugin-react": "^7.23.1",
-    "redux-logger": "^3.0.6"
+    "eslint-plugin-react": "^7.23.1"
   }
 }

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -1,18 +1,14 @@
-import { createStore, applyMiddleware} from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import logger from 'redux-logger';
-import rootReducer from '../reducers/root_reducer';
 
-let middleware = [thunk]
-if (process.env.NODE_ENV !== 'production') {
-  middleware = [...middleware, logger]
-}
+import rootReducer from '../reducers/root_reducer';
 
 const configureStore = (preloadedState = {}) => (
   createStore(
     rootReducer,
     preloadedState,
-    applyMiddleware(...middleware)
+    applyMiddleware(thunk, logger)
   )
 );
 


### PR DESCRIPTION
`import logger from 'redux-logger';` breaks heroku (and production builds) because redux-logger is no longer an installed module