### PR TITLE
/login path did not exist, fix profile logout bug

### DIFF
--- a/frontend/src/util/route_util.js
+++ b/frontend/src/util/route_util.js
@@ -19,7 +19,7 @@ const Protected = ({ component: Component, loggedIn, ...rest }) => (
       loggedIn ? (
         <Component {...props} />
       ) : (
-        <Redirect to="/login" />
+        <Redirect to="/" />
       )
     }
   />


### PR DESCRIPTION
if you log out on the profile right now, you get greeted with a 404 error